### PR TITLE
Update cflags include to use pkg-config

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
                 ['OS=="linux"', {
                     'include_dirs': [
                         '/usr/include/PCSC',
-                        '<!@(command -v pkg-config >/dev/null 2>&1 && pkg-config libpcsclite --cflags-only-I | sed s/-I//g)'
+                        '<!@(command -v pkg-config >/dev/null 2>&1 && pkg-config libpcsclite --cflags-only-I | sed s/-I//g)',
                         '<!(node -e "require(\'nan\')")'
                     ],
                     'link_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,7 @@
                 ['OS=="linux"', {
                     'include_dirs': [
                         '/usr/include/PCSC',
+                        '<!@(command -v pkg-config >/dev/null 2>&1 && pkg-config libpcsclite --cflags-only-I | sed s/-I//g)'
                         '<!(node -e "require(\'nan\')")'
                     ],
                     'link_settings': {


### PR DESCRIPTION
Update cflags include to use pkg-config if include directory is different then default /usr/include

We are using think package in an embedded system and we are not able to build this package within Yocto recipe since the includes are from different.

We can update the build to also respect the pkg-config value on Linux.